### PR TITLE
Warning fixed

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -44,7 +44,7 @@ const TrancodeRusToEngDict = {
 const TrancodeEngToRusDict = {};
 
 function generateIvertedDict(sourceDict, destDict) {
-    for(sourceindex in sourceDict)  {
+    for(let sourceindex in sourceDict)  {
         destDict[sourceDict[sourceindex]] = sourceindex;
     }
 }


### PR DESCRIPTION
Fixed annoying warning in log:
`JS WARNING: [~/.local/share/gnome-shell/extensions/transcode-appsearch@k.kubusha@gmail.com/extension.js 47]: assignment to undeclared variable sourceindex`